### PR TITLE
feat: first iteration of monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Use this plugin instead of the default
 [@semantic-release/npm](https://github.com/semantic-release/npm) if you want to
 use Yarn instead of the NPM CLI to publish your packages to the NPM registry.
 
-As an added bonus, this plugin will also publish some simple monorepo patterns
-(currently WIP).
+As an added bonus, this plugin will also publish some simple monorepo patterns.
 
 ## Table of contents
 
@@ -19,6 +18,7 @@ As an added bonus, this plugin will also publish some simple monorepo patterns
 - [Install](#install)
 - [Usage](#usage)
 - [NPM registry authentication](#npm-registry-authentication)
+- [Monorepo support](#monorepo-support)
 - [Configuration](#configuration)
   - [Environment variables](#environment-variables)
   - [`.yarnrc.yml` file](#yarnrcyml-file)
@@ -76,6 +76,24 @@ The NPM authentication configuration is **required** and can be set either via
 > [`npmAuthIdent`](https://yarnpkg.com/configuration/yarnrc/#npmAuthIdent)
 > (`username:password`) authentication is strongly discouraged and not supported
 > by this plugin.
+
+## Monorepo support
+
+Currently, simple monorepo versioning and publishing is supported. All
+workspaces versions will be aligned (a.k.a. fixed/locked mode) and when a new
+release is due, all workspaces will be published to the NPM registry.
+
+Monorepos are detected by the presence of a
+[`workspaces`](https://yarnpkg.com/configuration/manifest#workspaces) option in
+the root `package.json` file:
+
+```json
+{
+  "workspaces": ["packages/*"]
+}
+```
+
+See [our roadmap](#roadmap) for further implementation status.
 
 ## Configuration
 
@@ -195,6 +213,12 @@ For example with the
 ## Roadmap
 
 - [ ] Monorepo support
+  - [x] Support for fixed versions
+  - [x] Support for private/non-private root package
+  - [ ] Support for channels (added failing tests)
+  - [ ] Support for release information for each workspace
+  - [ ] Support for independant versions (probably impossible without custom
+        analyze-commits plugin)
 - [ ] Get rid of CJS build once
       [upstream PR 2607](https://github.com/semantic-release/semantic-release/pull/2607)
       lands

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,9 @@ export async function prepare(
     await verify(pluginConfig, context);
   }
 
-  await prepareNpm(pluginConfig, context);
+  const pkg = await getPkg(pluginConfig, context);
+
+  await prepareNpm(pluginConfig, pkg, context);
 
   prepared = true;
 }
@@ -71,11 +73,11 @@ export async function publish(
     await verify(pluginConfig, context);
   }
 
-  if (!prepared) {
-    await prepareNpm(pluginConfig, context);
-  }
-
   const pkg = await getPkg(pluginConfig, context);
+
+  if (!prepared) {
+    await prepareNpm(pluginConfig, pkg, context);
+  }
 
   return publishNpm(pluginConfig, pkg, context);
 }

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -34,7 +34,7 @@ export async function prepare(
     await pluginImportResult;
 
     logger.log("Running `yarn install` in %s", basePath);
-    const yarnInstallResult = execa("yarn", ["install"], {
+    const yarnInstallResult = execa("yarn", ["install", "--no-immutable"], {
       cwd: basePath,
       env,
     });

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,5 +1,6 @@
 import fs from "fs-extra";
 import { resolve } from "node:path";
+import type { PackageJson } from "read-pkg";
 import { getImplementation } from "./container.js";
 import type { PrepareContext } from "./definitions/context.js";
 import type { PluginConfig } from "./definitions/pluginConfig.js";
@@ -8,10 +9,39 @@ const TARBALL_FILENAME = "%s-%v.tgz";
 
 export async function prepare(
   { tarballDir, pkgRoot }: PluginConfig,
+  pkg: PackageJson,
   { cwd, env, stdout, stderr, nextRelease: { version }, logger }: PrepareContext
 ) {
   const basePath = pkgRoot ? resolve(cwd, String(pkgRoot)) : cwd;
   const execa = await getImplementation("execa");
+  const isMonorepo = typeof pkg.workspaces !== "undefined";
+  const workspacesPrefix = isMonorepo
+    ? ["workspaces", "foreach", "--topological", "--verbose", "--no-private"]
+    : [];
+
+  if (isMonorepo) {
+    logger.log("Installing Yarn workspace-tools plugin in %s", basePath);
+    const pluginImportResult = execa(
+      "yarn",
+      ["plugin", "import", "workspace-tools"],
+      {
+        cwd: basePath,
+        env,
+      }
+    );
+    pluginImportResult.stdout!.pipe(stdout, { end: false });
+    pluginImportResult.stderr!.pipe(stderr, { end: false });
+    await pluginImportResult;
+
+    logger.log("Running `yarn install` in %s", basePath);
+    const yarnInstallResult = execa("yarn", ["install"], {
+      cwd: basePath,
+      env,
+    });
+    yarnInstallResult.stdout!.pipe(stdout, { end: false });
+    yarnInstallResult.stderr!.pipe(stderr, { end: false });
+    await yarnInstallResult;
+  }
 
   logger.log("Installing Yarn version plugin in %s", basePath);
   const pluginImportResult = execa("yarn", ["plugin", "import", "version"], {
@@ -23,10 +53,14 @@ export async function prepare(
   await pluginImportResult;
 
   logger.log("Write version %s to package.json in %s", version, basePath);
-  const versionResult = execa("yarn", ["version", version, "--immediate"], {
-    cwd: basePath,
-    env,
-  });
+  const versionResult = execa(
+    "yarn",
+    [...workspacesPrefix, "version", version, "--immediate"],
+    {
+      cwd: basePath,
+      env,
+    }
+  );
   versionResult.stdout!.pipe(stdout, { end: false });
   versionResult.stderr!.pipe(stderr, { end: false });
   await versionResult;
@@ -36,7 +70,12 @@ export async function prepare(
     await fs.ensureDir(resolve(cwd, tarballDir.trim()));
     const packResult = execa(
       "yarn",
-      ["pack", "--out", resolve(cwd, tarballDir.trim(), TARBALL_FILENAME)],
+      [
+        ...workspacesPrefix,
+        "pack",
+        "--out",
+        resolve(cwd, tarballDir.trim(), TARBALL_FILENAME),
+      ],
       {
         cwd: basePath,
         env,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -50,7 +50,7 @@ export async function publish(
       await pluginImportResult;
 
       logger.log("Running `yarn install` in %s", basePath);
-      const yarnInstallResult = execa("yarn", ["install"], {
+      const yarnInstallResult = execa("yarn", ["install", "--no-immutable"], {
         cwd: basePath,
         env,
       });

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -7,9 +7,10 @@ import { getChannel } from "./get-channel.js";
 import { getRegistry } from "./get-registry.js";
 import { getReleaseInfo } from "./get-release-info.js";
 import { getYarnConfig } from "./get-yarn-config.js";
+import { reasonToNotPublish, shouldPublish } from "./should-publish.js";
 
 export async function publish(
-  { npmPublish, pkgRoot }: PluginConfig,
+  pluginConfig: PluginConfig,
   pkg: PackageJson,
   context: PublishContext
 ) {
@@ -21,21 +22,54 @@ export async function publish(
     nextRelease: { version, channel },
     logger,
   } = context;
+  const { pkgRoot } = pluginConfig;
   const execa = await getImplementation("execa");
 
-  if (npmPublish !== false && pkg.private !== true) {
+  if (shouldPublish(pluginConfig, pkg)) {
     const basePath = pkgRoot ? resolve(cwd, String(pkgRoot)) : cwd;
     const yarnrc = await getYarnConfig(context);
     const registry = getRegistry(pkg, yarnrc, context);
     const distTag = getChannel(channel!);
+    const isMonorepo = typeof pkg.workspaces !== "undefined";
+    const workspacesPrefix = isMonorepo
+      ? ["workspaces", "foreach", "--topological", "--verbose", "--no-private"]
+      : [];
+
+    if (isMonorepo) {
+      logger.log("Installing Yarn workspace-tools plugin in %s", basePath);
+      const pluginImportResult = execa(
+        "yarn",
+        ["plugin", "import", "workspace-tools"],
+        {
+          cwd: basePath,
+          env,
+        }
+      );
+      pluginImportResult.stdout!.pipe(stdout, { end: false });
+      pluginImportResult.stderr!.pipe(stderr, { end: false });
+      await pluginImportResult;
+
+      logger.log("Running `yarn install` in %s", basePath);
+      const yarnInstallResult = execa("yarn", ["install"], {
+        cwd: basePath,
+        env,
+      });
+      yarnInstallResult.stdout!.pipe(stdout, { end: false });
+      yarnInstallResult.stderr!.pipe(stderr, { end: false });
+      await yarnInstallResult;
+    }
 
     logger.log(
       `Publishing version ${version} to npm registry ${registry} on dist-tag ${distTag}`
     );
-    const result = execa("yarn", ["npm", "publish", "--tag", distTag], {
-      cwd: basePath,
-      env,
-    });
+    const result = execa(
+      "yarn",
+      [...workspacesPrefix, "npm", "publish", "--tag", distTag],
+      {
+        cwd: basePath,
+        env,
+      }
+    );
     result.stdout!.pipe(stdout, { end: false });
     result.stderr!.pipe(stderr, { end: false });
     await result;
@@ -47,11 +81,9 @@ export async function publish(
     return getReleaseInfo(pkg, context, distTag, registry);
   }
 
-  logger.log(
-    `Skip publishing to npm registry as ${
-      npmPublish === false ? "npmPublish" : "package.json's private property"
-    } is ${npmPublish !== false}`
-  );
+  const reason = reasonToNotPublish(pluginConfig, pkg);
+
+  logger.log(`Skip publishing to npm registry as ${reason}`);
 
   return false;
 }

--- a/src/should-publish.ts
+++ b/src/should-publish.ts
@@ -1,0 +1,34 @@
+import type { PackageJson } from "read-pkg";
+import type { PluginConfig } from "./definitions/pluginConfig.js";
+
+/**
+ * Returns [true, null] if `npmPublish` is not `false` and `pkg.private` is not
+ * `true` or `pkg.workspaces` is not `undefined`.
+ * Returns [false, reason] otherwise.
+ */
+function shouldPublishTuple(
+  pluginConfig: PluginConfig,
+  pkg: PackageJson
+): [boolean, string | null] {
+  const reasonToNotPublish =
+    pluginConfig.npmPublish === false
+      ? "npmPublish plugin option is false"
+      : pkg.private === true && typeof pkg.workspaces === "undefined"
+      ? "package is private and has no workspaces"
+      : null;
+
+  const shouldPublish = !reasonToNotPublish;
+
+  return [shouldPublish, reasonToNotPublish];
+}
+
+export function shouldPublish(pluginConfig: PluginConfig, pkg: PackageJson) {
+  return shouldPublishTuple(pluginConfig, pkg)[0];
+}
+
+export function reasonToNotPublish(
+  pluginConfig: PluginConfig,
+  pkg: PackageJson
+) {
+  return shouldPublishTuple(pluginConfig, pkg)[1];
+}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -2,6 +2,7 @@ import { getImplementation } from "./container.js";
 import type { VerifyConditionsContext } from "./definitions/context.js";
 import type { PluginConfig } from "./definitions/pluginConfig.js";
 import { getPkg } from "./get-pkg.js";
+import { shouldPublish } from "./should-publish.js";
 import { verifyAuth } from "./verify-auth.js";
 import { verifyConfig } from "./verify-config.js";
 import { verifyYarn } from "./verify-yarn.js";
@@ -23,9 +24,7 @@ export async function verify(
   try {
     const pkg = await getPkg(pluginConfig, context);
 
-    // Verify the npm authentication only if `npmPublish` is not false and
-    // `pkg.private` is not`true`
-    if (pluginConfig.npmPublish !== false && pkg.private !== true) {
+    if (shouldPublish(pluginConfig, pkg)) {
       await verifyAuth(pluginConfig, pkg, context);
     }
   } catch (error: any) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -871,3 +871,380 @@ test("Verify token and set up auth only on the fist call, then prepare on prepar
   });
   t.is((await getPackageTags(pkg.name, { cwd, env }))["latest"], "1.0.0");
 });
+
+test("Publish monorepo packages", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const env = authEnv;
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  await fs.outputJson(packagePath, {
+    name: "monorepo",
+    private: true,
+    workspaces: ["workspace-a", "workspace-b"],
+  });
+  await fs.outputJson(workspaceAPath, {
+    name: "monorepo-workspace-a",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "monorepo-workspace-b",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+
+  const result = await mod.publish(
+    {},
+    {
+      ...context,
+      env,
+      options: {},
+      releases: [],
+      commits: [],
+      lastRelease: { version: "0.0.0" },
+      nextRelease: { version: "1.0.0" },
+    }
+  );
+
+  // @todo: how to reflect each workspace in the result?
+  t.deepEqual(result, {
+    name: "npm package (@latest dist-tag)",
+    url: "https://www.npmjs.com/package/monorepo/v/1.0.0",
+    channel: "latest",
+  });
+  t.falsy((await fs.readJson(packagePath)).version);
+  t.is((await fs.readJson(workspaceAPath)).version, "1.0.0");
+  t.is((await fs.readJson(workspaceBPath)).version, "1.0.0");
+  t.false(await fs.pathExists(resolve(cwd, `monorepo-1.0.0.tgz`)));
+  t.false(await fs.pathExists(resolve(cwd, `monorepo-workspace-a-1.0.0.tgz`)));
+  t.false(await fs.pathExists(resolve(cwd, `monorepo-workspace-b-1.0.0.tgz`)));
+  await t.throwsAsync(getPackageVersion("monorepo", { cwd, env: testEnv }));
+  t.is(
+    await getPackageVersion("monorepo-workspace-a", { cwd, env: testEnv }),
+    "1.0.0"
+  );
+  t.is(
+    await getPackageVersion("monorepo-workspace-b", { cwd, env: testEnv }),
+    "1.0.0"
+  );
+});
+
+test.only("Publish non-private monorepo packages", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const env = authEnv;
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  await fs.outputJson(packagePath, {
+    name: "monorepo-non-private",
+    version: "0.0.0-dev",
+    workspaces: ["workspace-a", "workspace-b"],
+  });
+  await fs.outputJson(workspaceAPath, {
+    name: "monorepo-non-private-workspace-a",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "monorepo-non-private-workspace-b",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+
+  const result = await mod.publish(
+    {},
+    {
+      ...context,
+      env,
+      options: {},
+      releases: [],
+      commits: [],
+      lastRelease: { version: "0.0.0" },
+      nextRelease: { version: "1.0.0" },
+    }
+  );
+
+  // @todo: how to reflect each workspace in the result?
+  t.deepEqual(result, {
+    name: "npm package (@latest dist-tag)",
+    url: "https://www.npmjs.com/package/monorepo-non-private/v/1.0.0",
+    channel: "latest",
+  });
+  t.is((await fs.readJson(packagePath)).version, "1.0.0");
+  t.is((await fs.readJson(workspaceAPath)).version, "1.0.0");
+  t.is((await fs.readJson(workspaceBPath)).version, "1.0.0");
+  t.false(await fs.pathExists(resolve(cwd, `monorepo-non-private-1.0.0.tgz`)));
+  t.false(
+    await fs.pathExists(
+      resolve(cwd, `monorepo-non-private-workspace-a-1.0.0.tgz`)
+    )
+  );
+  t.false(
+    await fs.pathExists(
+      resolve(cwd, `monorepo-non-private-workspace-b-1.0.0.tgz`)
+    )
+  );
+  t.is(
+    await getPackageVersion("monorepo-non-private", { cwd, env: testEnv }),
+    "1.0.0"
+  );
+  t.is(
+    await getPackageVersion("monorepo-non-private-workspace-a", {
+      cwd,
+      env: testEnv,
+    }),
+    "1.0.0"
+  );
+  t.is(
+    await getPackageVersion("monorepo-non-private-workspace-b", {
+      cwd,
+      env: testEnv,
+    }),
+    "1.0.0"
+  );
+});
+
+test("Publish monorepo packages on a dist-tag", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const env = { ...authEnv };
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  await fs.outputJson(packagePath, {
+    name: "monorepo-publish-tag",
+    private: true,
+    workspaces: ["workspace-a", "workspace-b"],
+  });
+  await fs.outputJson(workspaceAPath, {
+    name: "monorepo-publish-tag-workspace-a",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "monorepo-publish-tag-workspace-b",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+
+  const result = await mod.publish(
+    {},
+    {
+      ...context,
+      env,
+      options: {},
+      releases: [],
+      commits: [],
+      lastRelease: { version: "0.0.0" },
+      nextRelease: { channel: "next", version: "1.0.0" },
+    }
+  );
+
+  // @todo: how to reflect each workspace in the result?
+  t.deepEqual(result, {
+    name: "npm package (@next dist-tag)",
+    url: "https://www.npmjs.com/package/monorepo-publish-tag/v/1.0.0",
+    channel: "next",
+  });
+  t.falsy((await fs.readJson(resolve(cwd, "package.json"))).version);
+  t.false(await fs.pathExists(resolve(cwd, `monorepo-publish-tag-1.0.0.tgz`)));
+  t.false(
+    await fs.pathExists(
+      resolve(cwd, `monorepo-publish-tag-workspace-a-1.0.0.tgz`)
+    )
+  );
+  t.false(
+    await fs.pathExists(
+      resolve(cwd, `monorepo-publish-tag-workspace-b-1.0.0.tgz`)
+    )
+  );
+  await t.throwsAsync(
+    getPackageVersion("monorepo-publish-tag", { cwd, env: testEnv })
+  );
+  t.is(
+    await getPackageVersion("monorepo-publish-tag-workspace-a", {
+      cwd,
+      env: testEnv,
+    }),
+    "1.0.0"
+  );
+  t.is(
+    await getPackageVersion("monorepo-publish-tag-workspace-b", {
+      cwd,
+      env: testEnv,
+    }),
+    "1.0.0"
+  );
+});
+
+test.failing(
+  "Publish monorepo packages and add to default dist-tag",
+  async (t) => {
+    const context = createContext();
+    const { cwd } = context;
+    const env = authEnv;
+    const packagePath = resolve(cwd, "package.json");
+    const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+    const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+    await fs.outputJson(packagePath, {
+      name: "monorepo-add-channel",
+      private: true,
+      workspaces: ["workspace-a", "workspace-b"],
+    });
+    await fs.outputJson(workspaceAPath, {
+      name: "monorepo-add-channel-workspace-a",
+      version: "0.0.0-dev",
+      publishConfig: { registry: url },
+    });
+    await fs.outputJson(workspaceBPath, {
+      name: "monorepo-add-channel-workspace-b",
+      version: "0.0.0-dev",
+      publishConfig: { registry: url },
+    });
+
+    await mod.publish(
+      {},
+      {
+        ...context,
+        env,
+        options: {},
+        releases: [],
+        commits: [],
+        lastRelease: { version: "0.0.0" },
+        nextRelease: { channel: "next", version: "1.0.0" },
+      }
+    );
+
+    const result = await mod.addChannel(
+      {},
+      {
+        ...context,
+        env,
+        options: {},
+        releases: [],
+        commits: [],
+        lastRelease: { version: "0.0.0" },
+        currentRelease: { version: "1.0.0" },
+        nextRelease: { version: "1.0.0" },
+      }
+    );
+
+    t.deepEqual(result, {
+      name: "npm package (@latest dist-tag)",
+      url: "https://www.npmjs.com/package/monorepo-add-channel/v/1.0.0",
+      channel: "latest",
+    });
+    await t.throwsAsync(getPackageTags("monorepo-add-channel", { cwd, env }));
+    t.is(
+      (await getPackageTags("monorepo-add-channel-workspace-a", { cwd, env }))[
+        "latest"
+      ],
+      "1.0.0"
+    );
+    t.is(
+      (await getPackageTags("monorepo-add-channel-workspace-b", { cwd, env }))[
+        "latest"
+      ],
+      "1.0.0"
+    );
+  }
+);
+
+test.failing("Publish monorepo packages and add to lts dist-tag", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const env = authEnv;
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  await fs.outputJson(packagePath, {
+    name: "monorepo-add-channel-legacy",
+    private: true,
+    workspaces: ["workspace-a", "workspace-b"],
+  });
+  await fs.outputJson(workspaceAPath, {
+    name: "monorepo-add-channel-legacy-workspace-a",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "monorepo-add-channel-legacy-workspace-b",
+    version: "0.0.0-dev",
+    publishConfig: { registry: url },
+  });
+
+  await mod.publish(
+    {},
+    {
+      ...context,
+      env,
+      options: {},
+      releases: [],
+      commits: [],
+      lastRelease: { version: "0.0.0" },
+      nextRelease: { channel: "latest", version: "1.0.0" },
+    }
+  );
+
+  const result = await mod.addChannel(
+    {},
+    {
+      ...context,
+      env,
+      options: {},
+      releases: [],
+      commits: [],
+      lastRelease: { version: "0.0.0" },
+      currentRelease: { version: "1.0.0" },
+      nextRelease: { channel: "1.x", version: "1.0.0" },
+    }
+  );
+
+  t.deepEqual(result, {
+    name: "npm package (@release-1.x dist-tag)",
+    url: "https://www.npmjs.com/package/monorepo-add-channel-legacy/v/1.0.0",
+    channel: "release-1.x",
+  });
+  await t.throwsAsync(
+    getPackageTags("monorepo-add-channel-legacy", { cwd, env })
+  );
+  t.is(
+    (
+      await getPackageTags("monorepo-add-channel-legacy-workspace-a", {
+        cwd,
+        env,
+      })
+    )["latest"],
+    "1.0.0"
+  );
+  t.is(
+    (
+      await getPackageTags("monorepo-add-channel-legacy-workspace-b", {
+        cwd,
+        env,
+      })
+    )["latest"],
+    "1.0.0"
+  );
+  t.is(
+    (
+      await getPackageTags("monorepo-add-channel-legacy-workspace-a", {
+        cwd,
+        env,
+      })
+    )["release-1.x"],
+    "1.0.0"
+  );
+  t.is(
+    (
+      await getPackageTags("monorepo-add-channel-legacy-workspace-b", {
+        cwd,
+        env,
+      })
+    )["release-1.x"],
+    "1.0.0"
+  );
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -931,7 +931,7 @@ test("Publish monorepo packages", async (t) => {
   );
 });
 
-test.only("Publish non-private monorepo packages", async (t) => {
+test("Publish non-private monorepo packages", async (t) => {
   const context = createContext();
   const { cwd } = context;
   const env = authEnv;

--- a/test/prepare.test.ts
+++ b/test/prepare.test.ts
@@ -8,18 +8,16 @@ test("Update package.json", async (t) => {
   const context = createContext();
   const { cwd } = context;
   const packagePath = resolve(cwd, "package.json");
-  await fs.outputJson(packagePath, { version: "0.0.0-dev" });
+  const pkg = { version: "0.0.0-dev" };
+  await fs.outputJson(packagePath, pkg);
 
-  await prepare(
-    {},
-    {
-      ...context,
-      releases: [],
-      commits: [],
-      lastRelease: { version: "0.0.0-dev" },
-      nextRelease: { version: "1.0.0" },
-    }
-  );
+  await prepare({}, pkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
 
   // Verify package.json has been updated
   t.is((await fs.readJson(packagePath)).version, "1.0.0");
@@ -43,18 +41,17 @@ test("Update package.json in a sub-directory", async (t) => {
   const { cwd } = context;
   const pkgRoot = "dist";
   const packagePath = resolve(cwd, pkgRoot, "package.json");
-  await fs.outputJson(packagePath, { version: "0.0.0-dev" });
+  const pkg = { version: "0.0.0-dev" };
 
-  await prepare(
-    { pkgRoot },
-    {
-      ...context,
-      releases: [],
-      commits: [],
-      lastRelease: { version: "0.0.0-dev" },
-      nextRelease: { version: "1.0.0" },
-    }
-  );
+  await fs.outputJson(packagePath, pkg);
+
+  await prepare({ pkgRoot }, pkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
 
   // Verify package.json has been updated
   t.is((await fs.readJson(packagePath)).version, "1.0.0");
@@ -71,18 +68,17 @@ test("Create the package tarball", async (t) => {
   const context = createContext();
   const { cwd } = context;
   const packagePath = resolve(cwd, "package.json");
-  await fs.outputJson(packagePath, { name: "my-pkg", version: "0.0.0-dev" });
+  const pkg = { name: "my-pkg", version: "0.0.0-dev" };
 
-  await prepare(
-    { tarballDir: "tarball" },
-    {
-      ...context,
-      releases: [],
-      commits: [],
-      lastRelease: { version: "0.0.0-dev" },
-      nextRelease: { version: "1.0.0" },
-    }
-  );
+  await fs.outputJson(packagePath, pkg);
+
+  await prepare({ tarballDir: "tarball" }, pkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
 
   // Verify package.json has been updated
   t.is((await fs.readJson(packagePath)).version, "1.0.0");
@@ -108,18 +104,16 @@ test("Create the package tarball in the current directory", async (t) => {
   const context = createContext();
   const { cwd } = context;
   const packagePath = resolve(cwd, "package.json");
-  await fs.outputJson(packagePath, { name: "my-pkg", version: "0.0.0-dev" });
+  const pkg = { name: "my-pkg", version: "0.0.0-dev" };
+  await fs.outputJson(packagePath, pkg);
 
-  await prepare(
-    { tarballDir: "." },
-    {
-      ...context,
-      releases: [],
-      commits: [],
-      lastRelease: { version: "0.0.0-dev" },
-      nextRelease: { version: "1.0.0" },
-    }
-  );
+  await prepare({ tarballDir: "." }, pkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
 
   // Verify the package has been created in the "tarballDir" directory
   t.is(await fs.pathExists(resolve(cwd, "my-pkg-1.0.0.tgz")), true);
@@ -136,19 +130,117 @@ test("Create the package tarball with package.json in sub-dir", async (t) => {
   const { cwd } = context;
   const pkgRoot = "dist";
   const packagePath = resolve(cwd, pkgRoot, "package.json");
-  await fs.outputJson(packagePath, { name: "my-pkg", version: "0.0.0-dev" });
+  const pkg = { name: "my-pkg", version: "0.0.0-dev" };
+  await fs.outputJson(packagePath, pkg);
 
-  await prepare(
-    { tarballDir: "tarball", pkgRoot },
-    {
-      ...context,
-      releases: [],
-      commits: [],
-      lastRelease: { version: "0.0.0-dev" },
-      nextRelease: { version: "1.0.0" },
-    }
-  );
+  await prepare({ tarballDir: "tarball", pkgRoot }, pkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
 
   // Verify the package has been created in the "tarballDir" directory
   t.true(await fs.pathExists(resolve(cwd, "tarball/my-pkg-1.0.0.tgz")));
+});
+
+test("Update monorepo package.json files", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  const rootPkg = {
+    private: true,
+    workspaces: ["workspace-a", "workspace-b"],
+  };
+  await fs.outputJson(packagePath, rootPkg);
+  await fs.outputJson(workspaceAPath, {
+    name: "workspace-a",
+    version: "0.0.0-dev",
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "workspace-b",
+    version: "0.0.0-dev",
+  });
+
+  await prepare({}, rootPkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
+
+  // Verify root package.json has not been updated
+  t.falsy((await fs.readJson(packagePath)).version);
+
+  // Verify workspaces package.json has been updated
+  t.is((await fs.readJson(workspaceAPath)).version, "1.0.0");
+  t.is((await fs.readJson(workspaceBPath)).version, "1.0.0");
+
+  // Verify the logger has been called with the workspace-tools plugin call
+  t.deepEqual(context.logger.log.args[0], [
+    "Installing Yarn workspace-tools plugin in %s",
+    cwd,
+  ]);
+
+  // Verify the logger has been called with the yarn install call
+  t.deepEqual(context.logger.log.args[1], [
+    "Running `yarn install` in %s",
+    cwd,
+  ]);
+
+  // Verify the logger has been called with the version plugin call
+  t.deepEqual(context.logger.log.args[2], [
+    "Installing Yarn version plugin in %s",
+    cwd,
+  ]);
+
+  // Verify the logger has been called with the version updated
+  t.deepEqual(context.logger.log.args[3], [
+    "Write version %s to package.json in %s",
+    "1.0.0",
+    cwd,
+  ]);
+});
+
+test("Create the monorepo package tarballs", async (t) => {
+  const context = createContext();
+  const { cwd } = context;
+  const packagePath = resolve(cwd, "package.json");
+  const workspaceAPath = resolve(cwd, "workspace-a", "package.json");
+  const workspaceBPath = resolve(cwd, "workspace-b", "package.json");
+  const rootPkg = {
+    private: true,
+    workspaces: ["workspace-a", "workspace-b"],
+  };
+  await fs.outputJson(packagePath, rootPkg);
+  await fs.outputJson(workspaceAPath, {
+    name: "workspace-a",
+    version: "0.0.0-dev",
+  });
+  await fs.outputJson(workspaceBPath, {
+    name: "workspace-b",
+    version: "0.0.0-dev",
+  });
+
+  await prepare({ tarballDir: "." }, rootPkg, {
+    ...context,
+    releases: [],
+    commits: [],
+    lastRelease: { version: "0.0.0-dev" },
+    nextRelease: { version: "1.0.0" },
+  });
+
+  // Verify the package has been created in the "tarballDir" directory
+  t.is(await fs.pathExists(resolve(cwd, "workspace-a-1.0.0.tgz")), true);
+  t.is(await fs.pathExists(resolve(cwd, "workspace-b-1.0.0.tgz")), true);
+
+  // Verify the logger has been called with the version updated
+  t.deepEqual(context.logger.log.args[4], [
+    "Creating package tarball in %s",
+    ".",
+  ]);
 });


### PR DESCRIPTION
- [x] Support for fixed versions
- [x] Support for private/non-private root package
- [x] Tests

Some implementation is still missing, most notably support in `add-channel.ts`