### PR TITLE
yarn plugins might be built-in

### DIFF
--- a/src/yarn-plugins.ts
+++ b/src/yarn-plugins.ts
@@ -34,9 +34,9 @@ export async function getYarnPlugins({ cwd }: { cwd: CommonContext["cwd"] }) {
 
   return stdout.split("\n").reduce((acc, line) => {
     try {
-      const { name, builtin } = JSON.parse(line);
+      const { name } = JSON.parse(line);
 
-      if (!builtin && name !== "@@core") {
+      if (name !== "@@core") {
         return [...acc, name.replace("@yarnpkg/plugin-", "")];
       }
     } catch {

--- a/test/yarn-plugins.test.ts
+++ b/test/yarn-plugins.test.ts
@@ -22,7 +22,15 @@ test.serial("getYarnPlugins", async (t) => {
 
   const plugins = await getYarnPlugins(context);
 
-  t.deepEqual(plugins, ["interactive-tools", "typescript", "version"]);
+  t.deepEqual(plugins, [
+    "essentials",
+    "compat",
+    "pnp",
+    "pnpm",
+    "interactive-tools",
+    "typescript",
+    "version",
+  ]);
 });
 
 test.serial("installYarnPluginIfNeeded when needed", async (t) => {
@@ -37,6 +45,14 @@ test.serial("installYarnPluginIfNeeded when not needed", async (t) => {
   const context = createContext();
 
   mockExeca({ stdout: '{"name":"@yarnpkg/plugin-version","builtin":false}' });
+
+  t.false(await installYarnPluginIfNeeded("version", context));
+});
+
+test.serial("installYarnPluginIfNeeded when builtin", async (t) => {
+  const context = createContext();
+
+  mockExeca({ stdout: '{"name":"@yarnpkg/plugin-version","builtin":true}' });
 
   t.false(await installYarnPluginIfNeeded("version", context));
 });


### PR DESCRIPTION
in yarn 4, all first-party plugins are installed by default. trying to install workspace-tools again fails.

ref: https://github.com/yarnpkg/berry/pull/4253